### PR TITLE
Update default delta_t2 value to be 9

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,8 +12,6 @@
 
 * lose the exported function `data_includes_tdm_scenarios()`.
 
-* `determine_tdm_variables` now sets `delta_t2 = 10` (used to be `9`).
-
 * `quit_if_no_pacta_relevant_data()` now also generates a PDF with the error message in place of the executive summary (#212).
 
 * `quit_if_no_pacta_relevant_data()` now fails on Bonds with no ALD in fin_sector (#194).

--- a/R/tdm_utility_functions.R
+++ b/R/tdm_utility_functions.R
@@ -69,7 +69,7 @@ determine_tdm_variables <- function(start_year) {
   list(
     t0 = start_year,
     delta_t1 = 5,
-    delta_t2 = 10,
+    delta_t2 = 9,
     additional_groups = c("scenario_source", "scenario", "allocation", "equity_market", "scenario_geography"),
     scenarios = tdm_scenarios()
   )


### PR DESCRIPTION
Relates to: https://github.com/RMI-PACTA/workflow.data.preparation/pull/49

Related: 
@cjyetman would you be in favour of removing this `determine_tdm_variables()` function?

To me this is setting configuration values (like the value of delta_t1 and delta_t2 values), which I feel like would make more sense to isolate in `workflow.transition.monitor`. 

Happy for the function to have sensible defaults, but I think we we are specifying the function configuration we should do it in a workflow.