### PR TITLE
Ensure that TDM can be calculate for a subset of input sectors

### DIFF
--- a/R/calculate_tdm.R
+++ b/R/calculate_tdm.R
@@ -95,7 +95,22 @@ calculate_tdm <- function(data,
     return(warn_zero_rows(tdm_prototype(), warning_message))
   }
 
-  data_with_monotonic_factors <- add_monotonic_factor(filtered_data, t0, delta_t1, delta_t2, groups)
+  tdm_years <- unique(t0, t0 + delta_t1, t0 + delta_t2)
+
+  data_with_relevant_years <- filtered_data %>%
+    dplyr::mutate(
+      has_all_years = all(tdm_years %in% .data$year),
+      .by = (union(crucial_tdm_groups(), additional_groups))
+    ) %>%
+    filter(.data$has_all_years)
+
+  if (nrow(data_with_relevant_years) == 0) {
+    warning_message <- "Filtering for relevant TDM years, outputs 0 rows"
+    write_log(warning_message, file_path = log_path)
+    return(warn_zero_rows(tdm_prototype(), warning_message))
+  }
+
+  data_with_monotonic_factors <- add_monotonic_factor(data_with_relevant_years, t0, delta_t1, delta_t2, groups)
 
   initial_year_data <- dplyr::filter(data_with_monotonic_factors, .data$year == t0)
 

--- a/R/tdm_conditions_met.R
+++ b/R/tdm_conditions_met.R
@@ -40,7 +40,7 @@ tdm_conditions_met <- function(data,
       .by = (union(crucial_tdm_groups(), additional_groups))
       )
 
-  valid_years_available <- all(has_useable_data_per_group$has_all_years)
+  valid_years_available <- any(has_useable_data_per_group$has_all_years)
 
   return(all(valid_project_code, valid_data_available, valid_years_available))
 }


### PR DESCRIPTION
What was happening: 
We had pretty strict TDM check requirements, that would only call `calculate_tdm` if EVERY possible combination of input data (e.g. If we have sufficient data to calculate the metric for the Power sector alone, but nothing else, then it doesn't even call the function). 

In the current world (where we can actually only feasibly calculate it for Power and Aviation), this is too strict and TDM will never show up. 

In this PR I have done two things: 
1 - I softened the requirement in `tdm_conditions_met` from an `all` to an `any`, meaning if ANY of the groups have the relevant information, we proceed with trying to calculate TDM
2 - `calculate_tdm()` now takes in the full dataset, then explicitly filters it only for groups that contain relevant information (as above)  