### PR TITLE
Remove coming soon from README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -43,7 +43,3 @@ series of repositories, each containing the prefix `workflow.*`.
 
 For example, the transition monitor platform is fuelled by the workflow found 
 here: https://github.com/RMI-PACTA/workflow.transition.monitor
-
-## Coming Soon
-
-A workflow to allow analysts to easily run PACTA locally...

--- a/README.md
+++ b/README.md
@@ -37,7 +37,3 @@ maintained in a series of repositories, each containing the prefix
 
 For example, the transition monitor platform is fuelled by the workflow
 found here: <https://github.com/RMI-PACTA/workflow.transition.monitor>
-
-## Coming Soon
-
-A workflow to allow analysts to easily run PACTA locally…


### PR DESCRIPTION
If anywhere, this should be in `workflow.transition.monitor`