### PR TITLE
remove GENERAL as a valid TDM initiative

### DIFF
--- a/R/tdm_conditions_met.R
+++ b/R/tdm_conditions_met.R
@@ -21,7 +21,8 @@ tdm_conditions_met <- function(data,
                                project_code,
                                additional_groups = NULL) {
 
-  valid_project_code <- project_code == "GENERAL"
+  # currently, no existing initiatives should have the TDM section
+  valid_project_code <- project_code == "XXX"
 
   useable_data <- data %>%
     filter(.data$allocation == "portfolio_weight") %>%

--- a/tests/testthat/test-tdm_conditions_met.R
+++ b/tests/testthat/test-tdm_conditions_met.R
@@ -15,7 +15,7 @@ test_that("passes TRUE, if at least one group of data contains all TDM years", {
     delta_t1,
     delta_t2,
     scenarios,
-    project_code = "GENERAL"
+    project_code = "XXX"
     )
 
   expect_equal(out, TRUE)


### PR DESCRIPTION
TDM should no longer be used in GENERAL reports, so the logic here needs to drop that hard-coded relationship.

related https://github.com/RMI-PACTA/pacta.portfolio.report/pull/39
related https://github.com/RMI-PACTA/templates.transition.monitor/pull/5

Update: had to also modify a test for `tdm_conditions_met()` which assumed that "GENERAL" is a valid project code