### PR TITLE
remove Vignette dependency from DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,6 +59,5 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
 Config/testthat/edition: 3
 Config/Needs/website: rmi-pacta/pacta.pkgdown.rmitemplate
-VignetteBuilder: knitr
 URL: https://github.com/RMI-PACTA/pacta.portfolio.allocate
 BugReports: https://github.com/RMI-PACTA/pacta.portfolio.allocate/issues


### PR DESCRIPTION
It appears that R CMD check throws a Note now if a Vignette dependency is declared but there are no vignettes to render.