### PR TITLE
enable "clean" on pkgdown action

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -45,6 +45,6 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4.6.3
         with:
-          clean: false
+          clean: true
           branch: gh-pages
           folder: docs


### PR DESCRIPTION
enable "clean" on pkgdown action to see if it will clear out old vignettes/articles that should no longer exist